### PR TITLE
Fix for getOnlinePlayers 1.9 API change

### DIFF
--- a/src/main/java/com/andune/minecraft/commonlib/server/bukkit/BukkitServer.java
+++ b/src/main/java/com/andune/minecraft/commonlib/server/bukkit/BukkitServer.java
@@ -267,11 +267,13 @@ public class BukkitServer implements Server, Initializable {
 
     @Override
     public Player[] getOnlinePlayers() {
-        org.bukkit.entity.Player[] bukkitOnline = plugin.getServer().getOnlinePlayers();
-        Player[] players = new Player[bukkitOnline.length];
-        for(int i=0; i < bukkitOnline.length; i++) {
-            players[i] = bukkitFactory.newBukkitPlayer(bukkitOnline[i]); 
-        }
+		Player[] players = new Player[plugin.getServer().getOnlinePlayers().size()];
+		int i = 0;
+		for (org.bukkit.entity.Player aOnline : plugin.getServer().getOnlinePlayers())
+		{
+			players[i] = bukkitFactory.newBukkitPlayer(aOnline);
+			i++;
+		}
         return players;
     }
 


### PR DESCRIPTION
getOnlinePlayers() now returns a collection, this should do the trick for the spigot 1.9 update
